### PR TITLE
Configurable tooltip position with live editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.10.0+26.1.2] - 2026-05-15
+
+**Compatible with Minecraft 26.1, 26.1.1, and 26.1.2**
+
+### Added
+- Configurable tooltip position (issue #26). The config screen has a
+  **Position Editor** entry opening a live editor screen:
+  - **Preset buttons** laid out spatially: top-left/center/right, and
+    bottom-left / **Action bar** / bottom-right.
+  - **X / Y inputs** (0–1 fraction) for precise placement.
+  - **Drag** the sample box anywhere; any of the three methods previews live
+    and a freehand placement is marked `Custom`.
+  - **Cancel** restores the position to what it was when the editor opened.
+- Position is stored as a normalized fraction of free screen space, so it is
+  independent of GUI scale and resolution.
+
+### Changed
+- **Default position is now `ACTION_BAR`** (centred, just above the hotbar —
+  `0.5 / 0.83`). New installs get this; existing configs keep their saved
+  value. The previous fixed 10px/40px bottom-right placement is gone.
+
+### Technical
+- First MINOR feature bump in the project's history (4.9.0 → 4.10.0); the
+  feature digit had been static at `9`.
+- The editor is the single live hub; `positionPreset`/`posX`/`posY` are
+  `@ConfigEntry.Gui.Excluded` (serialized, not shown as Cloth fields). The
+  HUD renders from a `PositionDraft` the editor edits live, so **Done** shows
+  in-game at once. Persistence stays Cloth's: `FreehandEditorEntry.isEdited()`
+  enables "Save & Quit", `save()` (Cloth `saveAll`, never on discard) commits
+  the draft to config. Cloth exposes no discard hook, so a client-tick check
+  (`screen == null && draft ≠ config`) re-seeds the draft from config — i.e. a
+  discard rolls the in-game position back too. **Cancel/Escape** in the editor
+  reverts the draft to the editor-open snapshot.
+- Cloth Config 26.1.x has no native button list-entry; the launcher is a
+  `TextListEntry` subclass registered via `AutoConfigClient.getGuiRegistry` +
+  `registerAnnotationProvider` on a `@FreehandEditorButton` marker field, with
+  bounds captured from `extractRenderState` so it only triggers on its own row.
+- Editor uses the MC 26.1 input/render API (`MouseButtonEvent`, `EditBox`,
+  `extractRenderState(GuiGraphicsExtractor, …)`).
+
 ## [4.9.0+26.1.2] - 2026-05-15
 
 **Compatible with Minecraft 26.1, 26.1.1, and 26.1.2**

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ minecraft_version=26.1.2
 loader_version=0.19.2
 
 # Mod Properties
-mod_version=4.9.0
+mod_version=4.10.0
 maven_group=com.thefredfox.minecraft.plugins.blockentitytooltip
 archives_base_name=block-entity-tooltip
 

--- a/src/client/kotlin/com/thefredfox/minecraft/plugins/blockentitytooltip/BlockEntityTooltipClient.kt
+++ b/src/client/kotlin/com/thefredfox/minecraft/plugins/blockentitytooltip/BlockEntityTooltipClient.kt
@@ -1,9 +1,13 @@
 package com.thefredfox.minecraft.plugins.blockentitytooltip
 
 import me.shedaniel.autoconfig.AutoConfig
+import me.shedaniel.autoconfig.AutoConfigClient
 import me.shedaniel.autoconfig.ConfigHolder
 import me.shedaniel.autoconfig.serializer.GsonConfigSerializer
+import me.shedaniel.clothconfig2.gui.AbstractConfigScreen
+import net.minecraft.client.gui.screens.ConfirmScreen
 import net.fabricmc.api.ClientModInitializer
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
 import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElement
 import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry
 import net.fabricmc.fabric.api.client.rendering.v1.hud.VanillaHudElements
@@ -38,6 +42,24 @@ object BlockEntityTooltipClient : ClientModInitializer {
             InteractionResult.SUCCESS
         }
         CONFIG = CONFIG_HOLDER.config
+        PositionDraft.loadFrom(CONFIG)
+        AutoConfigClient.getGuiRegistry(BlockEntityTooltipModConfig::class.java)
+            .registerAnnotationProvider(FREEHAND_GUI_PROVIDER, FreehandEditorButton::class.java)
+        // Discard inference: Cloth gives no quit/discard hook. The draft is
+        // legitimately diverged only while the config UI is in use — the Cloth
+        // screen itself, our editor, or the discard-confirm dialog. The moment
+        // we're on any other screen (parent screen after discard, or back in
+        // game) with the draft still diverged, the user left without saving:
+        // re-seed from config so the in-game position rolls back immediately.
+        ClientTickEvents.END_CLIENT_TICK.register { client ->
+            val s = client.screen
+            val inConfigUi = s is AbstractConfigScreen ||
+                s is PositionEditorScreen ||
+                s is ConfirmScreen
+            if (!inConfigUi && PositionDraft.differsFrom(CONFIG)) {
+                PositionDraft.loadFrom(CONFIG)
+            }
+        }
         HudElementRegistry.attachElementAfter(
             VanillaHudElements.CROSSHAIR,
             LAYER_IDENTIFIER,
@@ -102,21 +124,51 @@ class LookingAtRenderer : HudElement {
 
             val textWidth = font.width(textObj)
             val textHeight = font.lineHeight
+            val boxW = textWidth + padding * 2
+            val boxH = textHeight + padding * 2
 
-            val x = screenWidth - textWidth - 10
-            val y = screenHeight - textHeight - 40
-
-            val bgX1 = x - padding
-            val bgY1 = y - padding
-            val bgX2 = x + textWidth + padding
-            val bgY2 = y + textHeight + padding
+            val (boxX, boxY) = positionFor(
+                PositionDraft.preset, PositionDraft.posX, PositionDraft.posY,
+                screenWidth, screenHeight, boxW, boxH,
+            )
 
             val bgColor = ARGB.color(0x88, 0x0, 0x0, 0x0)
             val textColor = 0xFFFFFFFF.toInt()
 
-            graphics.fill(bgX1, bgY1, bgX2, bgY2, bgColor)
-            graphics.text(font, textObj, x, y, textColor)
+            graphics.fill(boxX, boxY, boxX + boxW, boxY + boxH, bgColor)
+            graphics.text(font, textObj, boxX + padding, boxY + padding, textColor)
         }
+    }
+}
+
+/**
+ * Maps the configured position to top-left pixel coordinates of the tooltip box.
+ *
+ * Presets and the freehand editor share this single formula so "what you drag is
+ * what you get". Position is expressed as a fraction of the free space
+ * (`screen - box`), making it independent of GUI scale and resolution.
+ * [PositionPreset.ACTION_BAR] is just the preset fraction (0.5, 0.83) — the
+ * spot just above the hotbar that the user dialed in.
+ */
+fun positionFor(
+    preset: PositionPreset,
+    posX: Double,
+    posY: Double,
+    screenW: Int,
+    screenH: Int,
+    boxW: Int,
+    boxH: Int,
+): Pair<Int, Int> {
+    val freeW = (screenW - boxW).coerceAtLeast(0)
+    val freeH = (screenH - boxH).coerceAtLeast(0)
+    return when (preset) {
+        PositionPreset.CUSTOM -> {
+            val x = (freeW * posX).toInt().coerceIn(0, freeW)
+            val y = (freeH * posY).toInt().coerceIn(0, freeH)
+            x to y
+        }
+
+        else -> (freeW * preset.fractionX).toInt() to (freeH * preset.fractionY).toInt()
     }
 }
 

--- a/src/client/kotlin/com/thefredfox/minecraft/plugins/blockentitytooltip/BlockEntityTooltipModConfig.kt
+++ b/src/client/kotlin/com/thefredfox/minecraft/plugins/blockentitytooltip/BlockEntityTooltipModConfig.kt
@@ -2,6 +2,44 @@ package com.thefredfox.minecraft.plugins.blockentitytooltip
 
 import me.shedaniel.autoconfig.ConfigData
 import me.shedaniel.autoconfig.annotation.Config
+import me.shedaniel.autoconfig.annotation.ConfigEntry
+import me.shedaniel.clothconfig2.gui.entries.SelectionListEntry
+
+private const val I18N = "text.autoconfig.block-entity-tooltip"
+
+/**
+ * Anchor presets. Non-special presets map to a normalized (fractionX, fractionY)
+ * pair; the renderer places the box with `pos = (screenSize - boxSize) * fraction`
+ * (0 = start edge, 1 = end edge, 0.5 = centered).
+ *
+ * [ACTION_BAR] is special-cased in the renderer (centered X, vanilla action-bar Y
+ * band). [CUSTOM] uses [BlockEntityTooltipModConfig.posX]/posY from the freehand
+ * editor.
+ *
+ * Implements [SelectionListEntry.Translatable] so the Cloth dropdown shows
+ * translated labels instead of raw enum names.
+ */
+enum class PositionPreset(val fractionX: Double, val fractionY: Double) :
+    SelectionListEntry.Translatable {
+    TOP_LEFT(0.0, 0.0),
+    TOP_CENTER(0.5, 0.0),
+    TOP_RIGHT(1.0, 0.0),
+    CENTER(0.5, 0.5),
+    BOTTOM_LEFT(0.0, 1.0),
+    BOTTOM_CENTER(0.5, 1.0),
+    BOTTOM_RIGHT(1.0, 1.0),
+
+    /** Just above the hotbar / where the vanilla action-bar text sits. */
+    ACTION_BAR(0.5, 0.83),
+    CUSTOM(1.0, 1.0);
+
+    override fun getKey(): String = "$I18N.option.positionPreset.$name"
+}
+
+/** Marker for the synthetic "open freehand editor" entry; see PositionConfigGui. */
+@Target(AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class FreehandEditorButton
 
 @Config(name = "block-entity-tooltip")
 class BlockEntityTooltipModConfig(
@@ -10,4 +48,25 @@ class BlockEntityTooltipModConfig(
     var showBlocks: Boolean = true,
     var showEntities: Boolean = true,
     var showFluids: Boolean = false,
+
+    // Managed entirely by PositionEditorScreen, not editable Cloth fields.
+    // @Gui.Excluded hides them from the config screen but they are still
+    // serialized (Gson) and persisted.
+    @ConfigEntry.Gui.Excluded
+    var positionPreset: PositionPreset = PositionPreset.ACTION_BAR,
+
+    /** Normalized box-position fraction (0..1), authoritative when [positionPreset] is [PositionPreset.CUSTOM]. */
+    @ConfigEntry.Gui.Excluded
+    var posX: Double = 0.5,
+
+    @ConfigEntry.Gui.Excluded
+    var posY: Double = 0.83,
+
+    /**
+     * Phantom field: value unused. Carries [FreehandEditorButton] so the
+     * registered GuiProvider injects the position-editor launcher entry into
+     * the main settings list. The editor is the single live position hub.
+     */
+    @FreehandEditorButton
+    var openFreehandEditor: Boolean = false,
 ) : ConfigData

--- a/src/client/kotlin/com/thefredfox/minecraft/plugins/blockentitytooltip/PositionConfigGui.kt
+++ b/src/client/kotlin/com/thefredfox/minecraft/plugins/blockentitytooltip/PositionConfigGui.kt
@@ -1,0 +1,121 @@
+package com.thefredfox.minecraft.plugins.blockentitytooltip
+
+import me.shedaniel.autoconfig.gui.registry.api.GuiProvider
+import me.shedaniel.clothconfig2.api.AbstractConfigListEntry
+import me.shedaniel.clothconfig2.gui.entries.TextListEntry
+import net.minecraft.ChatFormatting
+import net.fabricmc.api.EnvType
+import net.fabricmc.api.Environment
+import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.GuiGraphicsExtractor
+import net.minecraft.client.input.MouseButtonEvent
+import net.minecraft.network.chat.Component
+
+/**
+ * A button-like AutoConfig entry. Cloth Config 26.1.x has no native button
+ * list-entry, so this subclasses [TextListEntry] (which already implements the
+ * full 26.1 entry contract).
+ *
+ * Cloth's element list dispatches `mouseClicked` to entries that do NOT
+ * pre-filter by position (each entry must self-check bounds — the base
+ * TextListEntry does this via its text hit-test). So we capture the rendered
+ * row rectangle in [extractRenderState] and only act on a left click inside it;
+ * otherwise the editor would open for clicks anywhere in the screen.
+ */
+@Suppress("DEPRECATION") // all TextListEntry constructors are @Deprecated; a builder can't give us a subclass
+@Environment(EnvType.CLIENT)
+class FreehandEditorEntry(label: Component) :
+    TextListEntry(Component.literal("position_freehand"), label) {
+
+    private var rowX = 0
+    private var rowY = 0
+    private var rowW = 0
+
+    // The editor edits PositionDraft live (the HUD reads the draft, so Done
+    // shows in-game immediately). Persistence is Cloth's: isEdited() enables
+    // "Save & Quit" and the discard-confirm; save() (called by Cloth's
+    // saveAll, never on discard) commits the draft into CONFIG so the
+    // serializer writes it. Discard is inferred elsewhere via a tick check.
+    override fun isEdited(): Boolean = PositionDraft.differsFrom(CONFIG)
+
+    override fun save() {
+        PositionDraft.applyTo(CONFIG)
+        super.save()
+    }
+
+    override fun extractRenderState(
+        graphics: GuiGraphicsExtractor,
+        index: Int,
+        y: Int,
+        x: Int,
+        entryWidth: Int,
+        entryHeight: Int,
+        mouseX: Int,
+        mouseY: Int,
+        isHovered: Boolean,
+        delta: Float,
+    ) {
+        rowX = x
+        rowY = y
+        rowW = entryWidth
+        super.extractRenderState(
+            graphics, index, y, x, entryWidth, entryHeight, mouseX, mouseY, isHovered, delta,
+        )
+    }
+
+    override fun mouseClicked(event: MouseButtonEvent, doubleClick: Boolean): Boolean {
+        if (event.button() == 0 &&
+            event.x() >= rowX && event.x() <= rowX + rowW &&
+            event.y() >= rowY && event.y() <= rowY + itemHeight
+        ) {
+            val mc = Minecraft.getInstance()
+            mc.setScreen(PositionEditorScreen(mc.screen))
+            return true
+        }
+        return super.mouseClicked(event, doubleClick)
+    }
+}
+
+/**
+ * The position the HUD actually renders from. The editor mutates this live
+ * (so Done shows in-game at once). It is committed into [CONFIG] only by
+ * Cloth's "Save & Quit" ([FreehandEditorEntry.save]); a Cloth discard never
+ * calls save, and a tick check then re-seeds the draft from [CONFIG] so the
+ * in-game position rolls back too.
+ */
+object PositionDraft {
+    var preset: PositionPreset = PositionPreset.ACTION_BAR
+    var posX: Double = 0.5
+    var posY: Double = 0.83
+
+    fun loadFrom(c: BlockEntityTooltipModConfig) {
+        preset = c.positionPreset
+        posX = c.posX
+        posY = c.posY
+    }
+
+    fun applyTo(c: BlockEntityTooltipModConfig) {
+        c.positionPreset = preset
+        c.posX = posX
+        c.posY = posY
+    }
+
+    fun differsFrom(c: BlockEntityTooltipModConfig): Boolean =
+        preset != c.positionPreset || posX != c.posX || posY != c.posY
+}
+
+/**
+ * Registered for [FreehandEditorButton] in [BlockEntityTooltipClient]; replaces
+ * the phantom marker field's default widget with the "open editor" entry.
+ * Re-seeds [PositionDraft] from the committed config each time the screen builds.
+ */
+val FREEHAND_GUI_PROVIDER: GuiProvider = GuiProvider { _, _, _, _, _ ->
+    PositionDraft.loadFrom(CONFIG)
+    // Cloth 26.1 has no native button list-entry, so style the text to read
+    // as an action: leading arrow + gold accent (Minecraft's usual highlight
+    // colour). No underline — that read too much like an HTML hyperlink.
+    val label = Component.literal("▶ ")
+        .append(Component.translatable("text.autoconfig.block-entity-tooltip.option.openFreehandEditor"))
+        .withStyle(ChatFormatting.GOLD)
+    listOf<AbstractConfigListEntry<*>>(FreehandEditorEntry(label))
+}

--- a/src/client/kotlin/com/thefredfox/minecraft/plugins/blockentitytooltip/PositionEditorScreen.kt
+++ b/src/client/kotlin/com/thefredfox/minecraft/plugins/blockentitytooltip/PositionEditorScreen.kt
@@ -1,0 +1,239 @@
+package com.thefredfox.minecraft.plugins.blockentitytooltip
+
+import net.fabricmc.api.EnvType
+import net.fabricmc.api.Environment
+import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.GuiGraphicsExtractor
+import net.minecraft.client.gui.components.Button
+import net.minecraft.client.gui.components.EditBox
+import net.minecraft.client.gui.screens.Screen
+import net.minecraft.client.input.MouseButtonEvent
+import net.minecraft.network.chat.Component
+import net.minecraft.util.ARGB
+
+/**
+ * The single live position hub. Pick a preset, type X/Y fractions, or drag the
+ * box — all update [PositionDraft] and preview in the sample box.
+ *
+ * The HUD renders from the draft, so changes show in-game immediately.
+ * Done keeps the edited draft (Cloth's "Save & Quit" then persists it; a
+ * Cloth discard reverts it). Cancel / Escape roll the draft back to the
+ * snapshot taken when the editor opened.
+ */
+@Environment(EnvType.CLIENT)
+class PositionEditorScreen(private val parent: Screen?) :
+    Screen(Component.literal("Tooltip Position")) {
+
+    private val sampleText: Component = Component.literal("Diamond Block")
+    private val padding = 4
+
+    private var dragging = false
+    private var grabOffsetX = 0.0
+    private var grabOffsetY = 0.0
+
+    // Snapshot of the draft as it was when the editor opened (for Cancel).
+    private val origPreset = PositionDraft.preset
+    private val origPosX = PositionDraft.posX
+    private val origPosY = PositionDraft.posY
+
+    private val presetButtons = LinkedHashMap<PositionPreset, Button>()
+    private lateinit var inputX: EditBox
+    private lateinit var inputY: EditBox
+
+    /** Guards the EditBox responders while we set their text programmatically. */
+    private var syncingInputs = false
+
+    private fun round4(v: Double): Double = Math.round(v * 10000.0) / 10000.0
+
+    /** The fraction actually in effect: custom → posX/posY, else the preset's. */
+    private fun effectiveFraction(): Pair<Double, Double> =
+        if (PositionDraft.preset == PositionPreset.CUSTOM) {
+            PositionDraft.posX to PositionDraft.posY
+        } else {
+            PositionDraft.preset.fractionX to PositionDraft.preset.fractionY
+        }
+
+    private data class Box(val x: Int, val y: Int, val w: Int, val h: Int)
+
+    private fun box(): Box {
+        val font = Minecraft.getInstance().font
+        val w = font.width(sampleText) + padding * 2
+        val h = font.lineHeight + padding * 2
+        val (px, py) = positionFor(
+            PositionDraft.preset, PositionDraft.posX, PositionDraft.posY, width, height, w, h,
+        )
+        return Box(px, py, w, h)
+    }
+
+    /**
+     * Keep the live-edited draft and return to the Cloth screen. The HUD
+     * already reads the draft, so the in-game tooltip is at the new spot.
+     * Cloth's "Save & Quit" persists it; a Cloth discard reverts it.
+     */
+    private fun doneAndClose() {
+        Minecraft.getInstance().setScreen(parent)
+    }
+
+    /** Discard edits: restore the draft to the editor-open snapshot. */
+    private fun revertAndClose() {
+        PositionDraft.preset = origPreset
+        PositionDraft.posX = origPosX
+        PositionDraft.posY = origPosY
+        Minecraft.getInstance().setScreen(parent)
+    }
+
+    private fun selectPreset(preset: PositionPreset) {
+        PositionDraft.preset = preset
+        PositionDraft.posX = round4(preset.fractionX)
+        PositionDraft.posY = round4(preset.fractionY)
+        syncInputs()
+    }
+
+    private fun syncInputs() {
+        syncingInputs = true
+        val (fx, fy) = effectiveFraction()
+        inputX.value = round4(fx).toString()
+        inputY.value = round4(fy).toString()
+        syncingInputs = false
+    }
+
+    private fun onInputChanged() {
+        if (syncingInputs) return
+        val x = inputX.value.toDoubleOrNull() ?: return
+        val y = inputY.value.toDoubleOrNull() ?: return
+        PositionDraft.posX = round4(x.coerceIn(0.0, 1.0))
+        PositionDraft.posY = round4(y.coerceIn(0.0, 1.0))
+        PositionDraft.preset = PositionPreset.CUSTOM
+    }
+
+    override fun init() {
+        presetButtons.clear()
+        // 2 rows × 3 cols; ACTION_BAR sits where bottom-center would be
+        // (bottom-center / center omitted — the hotbar is there).
+        val layout = listOf(
+            Triple(PositionPreset.TOP_LEFT, 0, 0),
+            Triple(PositionPreset.TOP_CENTER, 1, 0),
+            Triple(PositionPreset.TOP_RIGHT, 2, 0),
+            Triple(PositionPreset.BOTTOM_LEFT, 0, 1),
+            Triple(PositionPreset.ACTION_BAR, 1, 1),
+            Triple(PositionPreset.BOTTOM_RIGHT, 2, 1),
+        )
+        val btnW = 96
+        val btnH = 20
+        val gap = 6
+        val gridW = 3 * btnW + 2 * gap
+        val startX = (width - gridW) / 2
+        val startY = 60
+        for ((preset, col, row) in layout) {
+            val button = Button.builder(Component.translatable(preset.key)) {
+                selectPreset(preset)
+            }.bounds(startX + col * (btnW + gap), startY + row * (btnH + gap), btnW, btnH).build()
+            presetButtons[preset] = button
+            addRenderableWidget(button)
+        }
+
+        val font = Minecraft.getInstance().font
+        val inputsY = startY + 2 * (btnH + gap) + 4
+        inputX = EditBox(font, width / 2 - 70, inputsY, 50, 18, Component.literal("X"))
+        inputY = EditBox(font, width / 2 + 30, inputsY, 50, 18, Component.literal("Y"))
+        listOf(inputX, inputY).forEach {
+            it.setMaxLength(8)
+            addRenderableWidget(it)
+        }
+        inputX.setResponder { onInputChanged() }
+        inputY.setResponder { onInputChanged() }
+        syncInputs()
+
+        val bottomY = height - 28
+        addRenderableWidget(
+            Button.builder(Component.literal("Cancel")) {
+                revertAndClose()
+            }.bounds(width / 2 - 154, bottomY, 100, 20).build()
+        )
+        addRenderableWidget(
+            Button.builder(Component.literal("Reset to default")) {
+                selectPreset(PositionPreset.ACTION_BAR)
+            }.bounds(width / 2 - 50, bottomY, 100, 20).build()
+        )
+        addRenderableWidget(
+            Button.builder(Component.literal("Done")) { doneAndClose() }
+                .bounds(width / 2 + 54, bottomY, 100, 20).build()
+        )
+    }
+
+    override fun extractRenderState(
+        graphics: GuiGraphicsExtractor,
+        mouseX: Int,
+        mouseY: Int,
+        partialTick: Float,
+    ) {
+        presetButtons.forEach { (preset, button) ->
+            button.active = PositionDraft.preset != preset
+        }
+        super.extractRenderState(graphics, mouseX, mouseY, partialTick)
+
+        val font = Minecraft.getInstance().font
+        val white = 0xFFFFFFFF.toInt()
+
+        val title = Component.literal("Tooltip Position")
+        graphics.text(font, title, width / 2 - font.width(title) / 2, 14, white)
+        val hint = Component.literal("Pick a preset, type X/Y (0–1), or drag the box.")
+        graphics.text(font, hint, width / 2 - font.width(hint) / 2, 30, white)
+        val current = Component.literal("Current: ")
+            .append(Component.translatable(PositionDraft.preset.key))
+        graphics.text(font, current, width / 2 - font.width(current) / 2, 44, white)
+
+        graphics.text(font, Component.literal("X"), inputX.x - 10, inputX.y + 5, white)
+        graphics.text(font, Component.literal("Y"), inputY.x - 10, inputY.y + 5, white)
+
+        val b = box()
+        graphics.fill(b.x, b.y, b.x + b.w, b.y + b.h, ARGB.color(0x88, 0x0, 0x0, 0x0))
+        graphics.text(font, sampleText, b.x + padding, b.y + padding, white)
+    }
+
+    override fun mouseClicked(event: MouseButtonEvent, doubleClick: Boolean): Boolean {
+        if (event.button() == 0) {
+            val b = box()
+            if (event.x() >= b.x && event.x() <= b.x + b.w &&
+                event.y() >= b.y && event.y() <= b.y + b.h
+            ) {
+                dragging = true
+                grabOffsetX = event.x() - b.x
+                grabOffsetY = event.y() - b.y
+                return true
+            }
+        }
+        return super.mouseClicked(event, doubleClick)
+    }
+
+    override fun mouseDragged(event: MouseButtonEvent, dragX: Double, dragY: Double): Boolean {
+        if (dragging) {
+            val b = box()
+            val freeW = (width - b.w).toDouble()
+            val freeH = (height - b.h).toDouble()
+            val newX = (event.x() - grabOffsetX).coerceIn(0.0, maxOf(0.0, freeW))
+            val newY = (event.y() - grabOffsetY).coerceIn(0.0, maxOf(0.0, freeH))
+            PositionDraft.posX = round4(if (freeW <= 0.0) 0.0 else newX / freeW)
+            PositionDraft.posY = round4(if (freeH <= 0.0) 0.0 else newY / freeH)
+            PositionDraft.preset = PositionPreset.CUSTOM
+            syncInputs()
+            return true
+        }
+        return super.mouseDragged(event, dragX, dragY)
+    }
+
+    override fun mouseReleased(event: MouseButtonEvent): Boolean {
+        if (dragging && event.button() == 0) {
+            dragging = false
+            return true
+        }
+        return super.mouseReleased(event)
+    }
+
+    // Escape / window close = Cancel (revert). Only the Done button commits.
+    override fun onClose() {
+        revertAndClose()
+    }
+
+    override fun isPauseScreen(): Boolean = false
+}

--- a/src/main/resources/assets/block-entity-tooltip/lang/en_us.json
+++ b/src/main/resources/assets/block-entity-tooltip/lang/en_us.json
@@ -1,8 +1,21 @@
 {
+  "text.autoconfig.block-entity-tooltip.title": "Block Entity Tooltip Settings",
+
   "text.autoconfig.block-entity-tooltip.option.enabled": "Show Tooltip",
   "text.autoconfig.block-entity-tooltip.option.distance": "Distance",
   "text.autoconfig.block-entity-tooltip.option.showBlocks": "Show Tooltip for Blocks",
   "text.autoconfig.block-entity-tooltip.option.showEntities": "Show Tooltip for Entities",
   "text.autoconfig.block-entity-tooltip.option.showFluids": "Show Tooltip for Fluids",
-  "text.autoconfig.block-entity-tooltip.title": "Block Entity Tooltip Settings"
+
+  "text.autoconfig.block-entity-tooltip.option.openFreehandEditor": "Position Editor",
+
+  "text.autoconfig.block-entity-tooltip.option.positionPreset.TOP_LEFT": "Top left",
+  "text.autoconfig.block-entity-tooltip.option.positionPreset.TOP_CENTER": "Top center",
+  "text.autoconfig.block-entity-tooltip.option.positionPreset.TOP_RIGHT": "Top right",
+  "text.autoconfig.block-entity-tooltip.option.positionPreset.CENTER": "Center",
+  "text.autoconfig.block-entity-tooltip.option.positionPreset.BOTTOM_LEFT": "Bottom left",
+  "text.autoconfig.block-entity-tooltip.option.positionPreset.BOTTOM_CENTER": "Bottom center",
+  "text.autoconfig.block-entity-tooltip.option.positionPreset.BOTTOM_RIGHT": "Bottom right",
+  "text.autoconfig.block-entity-tooltip.option.positionPreset.ACTION_BAR": "Action bar",
+  "text.autoconfig.block-entity-tooltip.option.positionPreset.CUSTOM": "Custom (freehand)"
 }


### PR DESCRIPTION
Closes #26

## What

Adds a **Position Editor** reachable from the mod config screen so users can place the block/entity tooltip anywhere on screen.

- **Presets**: spatial buttons — top left/center/right, bottom left/right, and **Action bar** (default; centred, just above the hotbar).
- **X / Y inputs**: precise normalized fraction (0–1).
- **Freehand drag**: drag the sample box anywhere.
- All three preview **live** (the HUD renders from a draft).

## Persistence model

The editor edits an in-memory `PositionDraft`; the HUD reads it, so **Done** shows the new position in-game immediately. Cloth's **Save & Quit** commits the draft to config. Cloth exposes no discard hook, so a client-tick check (`off the config UI && draft ≠ config`) re-seeds the draft from config — meaning a **discard rolls the in-game position back** too. Editor **Cancel/Escape** revert the draft to the editor-open snapshot.

## Notes

- `positionPreset`/`posX`/`posY` are `@ConfigEntry.Gui.Excluded` (serialized, not shown as Cloth fields); position is stored as a fraction of free screen space (GUI-scale / resolution independent).
- Cloth 26.1.x has no native button list-entry; the launcher is a `TextListEntry` subclass registered via `AutoConfigClient.getGuiRegistry` + `registerAnnotationProvider`, bounds-checked, styled gold to read as an action.
- Uses the MC 26.1 input/render API (`MouseButtonEvent`, `EditBox`, `extractRenderState(GuiGraphicsExtractor, …)`).
- First MINOR feature bump in the project's history (4.9.0 → 4.10.0). CHANGELOG updated for `4.10.0+26.1.2`.

## Testing

`./gradlew build` passes. Runtime-verified iteratively on MC 26.1.2 (presets, X/Y, drag, live preview, Save & Quit persist, discard revert).

— Written by Claude AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Screenshots:
<img width="1784" height="1080" alt="CleanShot 2026-05-16 at 23 44 07@2x" src="https://github.com/user-attachments/assets/e2ba6e51-056f-4499-affd-94fa53ad53df" />
<img width="2100" height="1364" alt="CleanShot 2026-05-16 at 23 44 41@2x" src="https://github.com/user-attachments/assets/efba9f7a-d8af-47c7-856f-3d53f82abe46" />
